### PR TITLE
change brooklyn address

### DIFF
--- a/packages/apps-config/src/endpoints/development.ts
+++ b/packages/apps-config/src/endpoints/development.ts
@@ -16,7 +16,7 @@ interface EnvWindow {
 }
 
 // TODO: Will be moved to config.
-const nodes = [{ link: 'wss://testnet.node.sydney.ggxchain.io', name: 'SYDNEY' }, { link: 'wss://testnet.node.brooklyn.ggxchain.io', name: 'BROOKLYN' }];
+const nodes = [{ link: 'wss://testnet.node.sydney.ggxchain.io', name: 'SYDNEY' }, { link: 'ws://18.193.253.223:9944', name: 'BROOKLYN' }];
 
 export function createCustom (t: TFunction): LinkOption[] {
   const WS_URL = (

--- a/packages/apps-config/src/endpoints/development.ts
+++ b/packages/apps-config/src/endpoints/development.ts
@@ -16,7 +16,7 @@ interface EnvWindow {
 }
 
 // TODO: Will be moved to config.
-const nodes = [{ link: 'wss://testnet.node.sydney.ggxchain.io', name: 'SYDNEY' }, { link: 'wss://18.193.253.223:9944', name: 'BROOKLYN' }];
+const nodes = [{ link: 'wss://testnet.node.sydney.ggxchain.io', name: 'SYDNEY' }, { link: 'wss://brooklyn-archive.dev.ggxchain.io:9944', name: 'BROOKLYN' }];
 
 export function createCustom (t: TFunction): LinkOption[] {
   const WS_URL = (

--- a/packages/apps-config/src/endpoints/development.ts
+++ b/packages/apps-config/src/endpoints/development.ts
@@ -16,7 +16,7 @@ interface EnvWindow {
 }
 
 // TODO: Will be moved to config.
-const nodes = [{ link: 'wss://testnet.node.sydney.ggxchain.io', name: 'SYDNEY' }, { link: 'ws://18.193.253.223:9944', name: 'BROOKLYN' }];
+const nodes = [{ link: 'wss://testnet.node.sydney.ggxchain.io', name: 'SYDNEY' }, { link: 'wss://18.193.253.223:9944', name: 'BROOKLYN' }];
 
 export function createCustom (t: TFunction): LinkOption[] {
   const WS_URL = (

--- a/packages/apps-config/src/endpoints/development.ts
+++ b/packages/apps-config/src/endpoints/development.ts
@@ -16,7 +16,7 @@ interface EnvWindow {
 }
 
 // TODO: Will be moved to config.
-const nodes = [{ link: 'wss://testnet.node.sydney.ggxchain.io', name: 'SYDNEY' }, { link: 'wss://brooklyn-archive.dev.ggxchain.io:9944', name: 'BROOKLYN' }];
+const nodes = [{ link: 'wss://sydney-archive.dev.ggxchain.io:9944', name: 'SYDNEY' }, { link: 'wss://brooklyn-archive.dev.ggxchain.io:9944', name: 'BROOKLYN' }];
 
 export function createCustom (t: TFunction): LinkOption[] {
   const WS_URL = (


### PR DESCRIPTION
we have migrated our instances from ec2 to EKS. This PR is for changing ws URLs for explorer. 
they are pointing to archive nodes. 